### PR TITLE
adds a test-runner that sends notifications to all apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 # VSCode specifics
 .vscode
 
-*.class
-
 # Package Files #
 *.jar
 *.war
@@ -26,3 +24,12 @@ release.properties
 
 .DS_Store
 *.checkstyle
+
+#Logs
+*.log
+*.log.zip
+
+#Project builds
+mock-data-loader/aerogear-mock-data-loader-1.0.0-SNAPSHOT
+
+

--- a/dynamic-test-driver/.gitignore
+++ b/dynamic-test-driver/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.vscode
+**/temp.js

--- a/dynamic-test-driver/README.md
+++ b/dynamic-test-driver/README.md
@@ -1,0 +1,13 @@
+# Dynamic Test Driver
+This is a test-runner written in nodeJS that sends a push notification to all applications of a user.
+
+#### Usage
+Having NPM and nodeJS installed, first download all dependencies:
+```
+$ npm install
+```
+Then start the test-runner passing your credentials as arguments:
+```
+$ node app/index.js <username> <password>
+```
+The test-runner will retrieve all the apps and iterate over them with a delay of 1000ms, sending a notification to all their tokens.

--- a/dynamic-test-driver/app/index.js
+++ b/dynamic-test-driver/app/index.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const API = require("./src/ups-api");
+const TestRunner = require("./src/test-runner");
+
+// Take the necessary command line arguments.
+const username = process.argv[2];
+const password = process.argv[3];
+
+if (!username || !password) {
+    console.log("usage: node index.js <username> <password>");
+    process.exit(1);
+}
+
+API.getApplications(username, password)
+    .then(TestRunner.start)

--- a/dynamic-test-driver/app/model/message.js
+++ b/dynamic-test-driver/app/model/message.js
@@ -1,0 +1,20 @@
+"use strict";
+
+const DEFAULT_MESSAGE_SOUND = "default";
+const DEFAULT_MESSAGE_PRIORITY = "normal";
+const DEFAULT_MESSAGE_SIMPLE_PUSH = "version=1485353624158";
+
+class Message {
+    constructor(alert) {
+        this.alert = alert;
+        this.priority = DEFAULT_MESSAGE_PRIORITY;
+        this.sound = DEFAULT_MESSAGE_SOUND;
+        this.badge;
+        this.simplePush;
+        this.userData;
+        this.apns;
+        this.windows;
+    }
+}
+
+module.exports = Message;

--- a/dynamic-test-driver/app/model/options.js
+++ b/dynamic-test-driver/app/model/options.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const DEFAULT_CRITERIA_ALIAS = ["TEST_TOKEN"]
+const DEFAULT_CONFIG_TTL = -1;
+
+class Options {
+    constructor() {
+        this.config = new Config();
+        this.criteria = new Criteria();
+    }
+}
+
+class Criteria {
+    constructor() {
+        this.alias = DEFAULT_CRITERIA_ALIAS;
+        this.deviceType;
+        this.categories;
+        this.variants;
+    }
+}
+
+class Config {
+    constructor() {
+        this.ttl = DEFAULT_CONFIG_TTL;
+    }
+}
+
+module.exports = Options;

--- a/dynamic-test-driver/app/src/test-runner.js
+++ b/dynamic-test-driver/app/src/test-runner.js
@@ -17,7 +17,7 @@ class TestRunner {
         apps.forEach((app, i) => {
             setTimeout(() => {
                 API.sendNotificationToApp(message, app, options)
-            }, 1000 * i);
+            }, DELAY * i);
         });
     }
 }

--- a/dynamic-test-driver/app/src/test-runner.js
+++ b/dynamic-test-driver/app/src/test-runner.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const API = require("./ups-api");
+const Message = require("../model/message");
+const Options = require("../model/options");
+
+const DELAY = 1000;
+
+class TestRunner {
+
+    static start(apps) {
+        console.log(`Total apps: ${apps.length}`);
+
+        const message = new Message(`Testing!!`);
+        const options = new Options();
+
+        apps.forEach((app, i) => {
+            setTimeout(() => {
+                API.sendNotificationToApp(message, app, options)
+            }, 1000 * i);
+        });
+    }
+}
+
+module.exports = TestRunner;

--- a/dynamic-test-driver/app/src/ups-api.js
+++ b/dynamic-test-driver/app/src/ups-api.js
@@ -31,11 +31,11 @@ class API {
      * @returns {Promise} An empty promise if the notification was sent.
      */
     static sendNotificationToApp(message, app, options) {
-        console.log(`Sending message to "${app.name}" {${app.id}}`)
+        console.log(`Sending message to "${app.name}" {${app.pushApplicationID}}`)
 
         const settings = {
             url: BASE_URL,
-            applicationId: app.id,
+            applicationId: app.pushApplicationID,
             masterSecret: app.masterSecret
         }
 

--- a/dynamic-test-driver/app/src/ups-api.js
+++ b/dynamic-test-driver/app/src/ups-api.js
@@ -1,0 +1,47 @@
+"use strict";
+
+const adminClient = require("unifiedpush-admin-client");
+const senderClient = require("unifiedpush-node-sender");
+
+const BASE_URL = "http://localhost:8080/ag-push";
+
+class API {
+
+    /**
+     * Returns the list of applications
+     * @argument {string} username Account's username for authentication
+     * @argument {string} password Account's password for authentication
+     * @returns {Promise} A promise containing all the applications in user's account.
+     */
+    static getApplications(username, password) {
+        const settings = {
+            username,
+            password
+        };
+
+        return adminClient(BASE_URL, settings)
+            .then(client => client.applications.find());
+    }
+
+    /**
+     * Sends a push notification to an application
+     * @argument {Message} message An instance of Message class containing all information.
+     * @argument {Application} app The application that will be target of the notification
+     * @argument {Options} options An instance of Options class containing some optional parameters.
+     * @returns {Promise} An empty promise if the notification was sent.
+     */
+    static sendNotificationToApp(message, app, options) {
+        console.log(`Sending message to "${app.name}" {${app.id}}`)
+
+        const settings = {
+            url: BASE_URL,
+            applicationId: app.id,
+            masterSecret: app.masterSecret
+        }
+
+        return senderClient(settings)
+            .then(client => client.sender.send(message, options))
+    }
+}
+
+module.exports = API;

--- a/dynamic-test-driver/package.json
+++ b/dynamic-test-driver/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "dynamic-test-driver",
+  "version": "1.0.0",
+  "description": "A test driver in nodeJS that runs SEND requests against the mocked UPS data",
+  "main": "test-driver.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Jose Miguel Gallas Olmedo",
+  "license": "MIT",
+  "dependencies": {
+    "unifiedpush-admin-client": "^0.5.0",
+    "unifiedpush-node-sender": "^0.14.1"
+  }
+}

--- a/dynamic-test-driver/package.json
+++ b/dynamic-test-driver/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "Jose Miguel Gallas Olmedo",
-  "license": "MIT",
+  "author": "Aerogear team",
+  "license": "Apache",
   "dependencies": {
     "unifiedpush-admin-client": "^0.5.0",
     "unifiedpush-node-sender": "^0.14.1"


### PR DESCRIPTION
This PR resolves this ticket: https://issues.jboss.org/browse/AGPUSH-2003

Adds a test-runner, written in nodeJS, to the current test suite. This test runner gets all applications from one user and send 1 notification to all of them with the single alias "TEST_TOKEN" that is the one mock-data-loader creates for all fake devices.

This test runner uses both community libraries: https://github.com/bucharest-gold/unifiedpush-admin-client (for retrieving the apps) and https://github.com/aerogear/aerogear-unifiedpush-nodejs-client/ (for sending the notifications).

