### PR TITLE
Add batched test runner

### DIFF
--- a/rhmap-test-driver/.gitignore
+++ b/rhmap-test-driver/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .vscode
 **/temp.js
-**/devices.csv
+**/*.csv
 **/notes.js
+**.log

--- a/rhmap-test-driver/README.md
+++ b/rhmap-test-driver/README.md
@@ -6,14 +6,23 @@ Having NPM and nodeJS installed, first download all dependencies:
 ```
 $ npm install
 ```
-Then start the test-runner passing the necessary arguments:
+Then start the test-runner by running `node index.js` and passing, at least, `-e`, `a` and `c` arguments. To see usage instructions run `node index.js -h`:
 ```
-$ node index.js <endpoint url> <appId> <path/to/devices.csv> <delay>
+Usage: node index.js [options]
+
+Options:
+  -e, --endPoint   The backend url                                    [required]
+  -a, --appId      The ID of the application that owns the target aliases
+                                                                      [required]
+  -c, --csv        The path to the CSV path containing the aliases    [required]
+  -d, --delay      The delay between each request                [default: 6500]
+  -b, --batched    If the aliases are sent in batches [boolean] [default: false]
+  -s, --batchSize  The amount of aliases for each batch           [default: 500]
+  -h, --help       Show help                                           [boolean]
+
+Examples:
+  app/index.js -e http://example.com/backend -a asdf12134 -c ./devices.csv
+  app/index.js -e http://example.com/backend -a asdf12134 -c ./devices.csv -d 100 -b -s 1000
+
 ```
-`endpoint url` -> URL to your backend cloud app.
 
-`appId` -> The ID of the application that owns the devices.
-
-`path/to/devices.csv` -> The path to the CSV file that has all tokens.
-
-`delay` -> The time in ms that will separate each request to the endpoint.

--- a/rhmap-test-driver/app/src/rhmap-api.js
+++ b/rhmap-test-driver/app/src/rhmap-api.js
@@ -18,6 +18,24 @@ class API {
 
         return new Promise(executor);
     }
+
+    sendNotificationToAliases(appId, aliases) {
+        const executor = (resolve, reject) => {
+            const options = {
+                uri: `${this.baseUrl}/push/${appId}`,
+                body: JSON.stringify(aliases),
+                headers: {
+                    "content-type": "application/json"
+                }
+            }
+            request.post(options, (err, res) => {
+                if (err) reject(err);
+                else resolve(res);
+            });
+        };
+
+        return new Promise(executor);
+    }
 }
 
 module.exports = API;

--- a/rhmap-test-driver/app/src/test-runner-batched.js
+++ b/rhmap-test-driver/app/src/test-runner-batched.js
@@ -1,0 +1,44 @@
+"use strict";
+
+const TestRunner = require("./test-runner");
+const API = require("./rhmap-api");
+const async = require("async");
+const Utils = require("./utils");
+
+class TestRunnerBatched extends TestRunner {
+
+    constructor(args) {
+        super(args);
+        // The amount of aliases to send each time
+        this.batchSize = args.batchSize
+    }
+
+    /**
+     * It sends a request to the backend endpoint for a batch of aliases with a fix delay in between
+     */
+    start(aliases) {
+        super.start();
+
+        const batches = this.splitAliasesInBatches(aliases);
+
+        const startTime = Date.now();
+
+        Utils.forEachAsyncWithInterval(batches, batch => {
+            console.log(`Sending notification to ${batch.length} aliases at ${Date.now() - startTime}`);
+            this.api.sendNotificationToAliases(this.appId, batch)
+                .then(res => console.log(`RESPONSE: ${res.statusCode} - ${res.body}`))
+                .catch(err => console.log(`ERROR: ${err}`));
+        }, this.delay);
+    }
+
+    splitAliasesInBatches(aliases) {
+        const totalBatches = Math.ceil(aliases.length / this.batchSize);
+        const batches = [totalBatches];
+        for (let i = 0; i < totalBatches; i++) {
+            batches[i] = aliases.splice(0, this.batchSize);
+        }
+        return batches;
+    }
+}
+
+module.exports = TestRunnerBatched;

--- a/rhmap-test-driver/app/src/test-runner-iterative.js
+++ b/rhmap-test-driver/app/src/test-runner-iterative.js
@@ -1,0 +1,31 @@
+"use strict";
+
+const TestRunner = require("./test-runner");
+const API = require("./rhmap-api");
+const async = require("async");
+const Utils = require("./utils");
+
+class TestRunnerIterative extends TestRunner {
+
+    constructor() {
+        super();
+    }
+
+    /**
+     * It sends a request to the backend endpoint for each alias with a fix delay between each one
+     */
+    start(aliases) {
+        super.start();
+
+        const startTime = Date.now();
+
+        Utils.forEachAsyncWithInterval(aliases, alias => {
+            console.log(`Sending notification to ${alias} at ${Date.now() - startTime}`);
+            this.api.sendNotificationToAlias(this.appId, alias)
+                .then(res => console.log(`[${alias}] RESPONSE: ${res.statusCode} - ${res.body}`))
+                .catch(err => console.log(`[${alias}] ERROR: ${err}`));
+        }, this.delay);
+    }
+}
+
+module.exports = TestRunnerIterative;

--- a/rhmap-test-driver/app/src/test-runner.js
+++ b/rhmap-test-driver/app/src/test-runner.js
@@ -6,16 +6,15 @@ const Utils = require("./utils");
 
 class TestRunner {
 
-    constructor() {
+    constructor(args) {
+        // The url of the cloud app endpoint
+        this.endPoint = args.endPoint;
         // The ID of the application that owns the target aliases.
-        this.appId;
+        this.appId = args.appId;
         // The time between one request and another
-        this.delay;
+        this.delay = args.delay;
     }
 
-    /**
-     * The URL of the node backend
-     */
     set endPoint(endPoint) {
         if (endPoint.lastIndexOf('/') === endPoint.length - 1) {
             endPoint.slice(-1);
@@ -24,21 +23,12 @@ class TestRunner {
     }
 
     /**
-     * It sends a request to the backend endpoint for each alias with a fix delay between each one
+     * Here's all the verification and common logic for start method.
      */
-    start(aliases) {
+    start() {
         if (!this.api || !this.appId) {
             throw new Error("An endpoint URL and an application ID must be provided");
         }
-
-        const startTime = Date.now();
-
-        Utils.forEachAsyncWithInterval(aliases, alias => {
-            console.log(`Sending notification to ${alias} at ${Date.now() - startTime}`);
-            this.api.sendNotificationToAlias(this.appId, alias)
-                .then(res => console.log(`[${alias}] RESPONSE: ${res.statusCode} - ${res.body}`))
-                .catch(err => console.log(`[${alias}] ERROR: ${err}`));
-        }, this.delay);
     }
 }
 


### PR DESCRIPTION
The Cloud App has a new route that accepts an array of aliases. Internally the app will iterate over that array and send a notification to each one using `fh.push`. This PR updates the test-driver by adding this new variant and improving other details.